### PR TITLE
Login with email instead of username.  Custom signup form added.

### DIFF
--- a/RedInvestigadores/RedInvestigadores/settings.py
+++ b/RedInvestigadores/RedInvestigadores/settings.py
@@ -38,6 +38,11 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
+
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
 ]
 
 MIDDLEWARE = [
@@ -82,7 +87,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'db_red_investigadores',
-        'USER': 'postgres',
+        'USER': 'username',
         'PASSWORD': '',
         'HOST': '127.0.0.1',
         'PORT': '5432',
@@ -114,19 +119,19 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE     = 'UTC'
 
-USE_I18N = True
+USE_I18N      = True
 
-USE_L10N = True
+USE_L10N      = True
 
-USE_TZ = True
+USE_TZ        = True
 
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL  = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATICFILES_FINDERS = (
   'django.contrib.staticfiles.finders.FileSystemFinder',
@@ -135,7 +140,24 @@ STATICFILES_FINDERS = (
 TEMPLATE_DIRS = (
     os.path.join(BASE_DIR, 'templates'),
 )
-EMAIL_BACKEND= 'django.core.mail.backends.console.EmailBackend'
-EMAIL_FILE_PATH = os.path.join(BASE_DIR,"sent_emails")
-LOGIN_REDIRECT_URL = 'home'
+
+AUTHENTICATION_BACKENDS = (
+    "django.contrib.auth.backends.ModelBackend",
+    "allauth.account.auth_backends.AuthenticationBackend",
+)
+
+SITE_ID = 1
+
+ACCOUNT_EMAIL_REQUIRED              = True
+ACCOUNT_USERNAME_REQUIRED           = False
+ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE = False
+ACCOUNT_SESSION_REMEMBER            = True
+ACCOUNT_AUTHENTICATION_METHOD       = 'email'
+ACCOUNT_UNIQUE_EMAIL                = True
+ACCOUNT_FORMS                       = {'login': 'core.forms.CustomLoginForm',
+                                       'signup': 'core.forms.CustomSignupForm'}
+
+EMAIL_BACKEND       = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_FILE_PATH     = os.path.join(BASE_DIR,"sent_emails")
+LOGIN_REDIRECT_URL  = 'home'
 LOGOUT_REDIRECT_URL = 'home'

--- a/RedInvestigadores/RedInvestigadores/urls.py
+++ b/RedInvestigadores/RedInvestigadores/urls.py
@@ -18,12 +18,13 @@ from django.urls import path, include
 from core import views
 from django.conf.urls import url
 from django.contrib.auth import views as auth_views
-from core.forms import LoginForm
+from core.forms import LoginForm, CustomUserCreationForm
 
 urlpatterns = [
     path('login/',auth_views.LoginView.as_view(template_name='registration/login.html',
-        authentication_form=LoginForm)),
+        authentication_form=LoginForm), name='login'),
     path('admin/', admin.site.urls),
+    path('accounts/', include('allauth.urls')),
     path('', views.home, name = 'home'),
     path('home/', views.home, name='home'),
     path('profile/<int:user_id>', views.get_user_profile, name='profile'),

--- a/RedInvestigadores/core/admin.py
+++ b/RedInvestigadores/core/admin.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
 from django.utils.translation import ugettext_lazy as _
 
-from .forms import LoginForm,CustomUserCreationForm, CustomUserChangeForm
+from .forms import LoginForm, CustomUserCreationForm, CustomUserChangeForm
 
 from .models import *
 
@@ -24,5 +24,4 @@ admin.site.register(Person)
 admin.site.register(Postdoc)
 admin.site.register(Publication)
 admin.site.register(Researcher)
-admin.site.register(Role)
 admin.site.register(Student)

--- a/RedInvestigadores/core/forms.py
+++ b/RedInvestigadores/core/forms.py
@@ -1,7 +1,29 @@
 from django import forms
-from django.contrib.auth.forms import  AuthenticationForm, UserCreationForm, UserChangeForm
-from .models import CustomUser
+from django.contrib.auth.forms import AuthenticationForm, UserCreationForm, UserChangeForm
+from .models import CustomUser, Person, State
 from django.utils.translation import ugettext_lazy as _
+from allauth.account.forms import LoginForm, SignupForm
+
+class CustomLoginForm(LoginForm):
+    def __init__(self, *args, **kwargs):
+        super(CustomLoginForm, self).__init__(*args, **kwargs)
+        self.fields['password'].label  = 'Ingresa tu contraseña'
+        self.fields['password'].widget = forms.PasswordInput(attrs={'placeholder':'Contraseña'})
+        self.fields['login'].label     = 'Escribe tu correo'
+        self.fields['login'].widget    = forms.TextInput(attrs={'placeholder':'Correo electrónico'})
+
+class CustomSignupForm(SignupForm):
+    first_name = forms.CharField(max_length=30, label='Nombres')
+    last_name  = forms.CharField(max_length=30, label='Apellidos')
+    email      = forms.EmailField(label='Correo Electrónico')
+    state      = forms.ModelChoiceField(queryset=State.objects.all(), label='Estado')
+
+    def signup(self, request, user):
+        user.first_name = self.cleaned_data['first_name']
+        user.last_name  = self.cleaned_data['last_name']
+        user.email      = self.cleaned_data['email']
+        user.save()
+        return user
 
 class LoginForm(AuthenticationForm):
     def __init__(self, request,*args, **kwargs):
@@ -13,12 +35,11 @@ class LoginForm(AuthenticationForm):
         model = CustomUser
         fields=('username','password')
 
-
 class CustomUserCreationForm(UserCreationForm):
     def __init__(self, *args, **kwargs):
         super(UserCreationForm, self).__init__(*args, **kwargs)
-        self.fields['username'].label = 'Usuario'
-        self.fields['email'].label = 'Correo Electrónico'
+        self.fields['username'].label  = 'Usuario'
+        self.fields['email'].label     = 'Correo Electrónico'
         self.fields['password1'].label = 'Contraseña'
         self.fields['password2'].label = 'Confirma tu contraseña'
 
@@ -35,10 +56,10 @@ class CustomUserCreationForm(UserCreationForm):
 class CustomUserChangeForm(UserChangeForm):
     def __init__(self, *args, **kwargs):
         super(UserChangeForm, self).__init__(*args, **kwargs)
-        self.fields['username'].label = "Usuario"
+        self.fields['username'].label   = "Usuario"
         self.fields['first_name'].label = "Nombres"
-        self.fields['last_name'].label = "Apellidos"
-        self.fields['email'].label = "Correo electrónico"
+        self.fields['last_name'].label  = "Apellidos"
+        self.fields['email'].label      = "Correo electrónico"
 
     class Meta:
         model = CustomUser

--- a/RedInvestigadores/core/models.py
+++ b/RedInvestigadores/core/models.py
@@ -102,10 +102,10 @@ class Person(models.Model):
 @receiver(post_save, sender = CustomUser)
 def create_person_profile(sender, instance, created, **kwargs):
     if created:
-        Person.objects.create(first_name = 'No ha introducido esta información',
-                              last_name = 'No ha introducido esta información',
-                              orcid = instance.__str__(),
-                              user = instance)
+        Person.objects.create(first_name = instance.first_name,
+                              last_name  = instance.last_name,
+                              orcid      = instance.__str__(),
+                              user       = instance)
 
 class PersonRole(models.Model):
     person = models.ForeignKey(Person, on_delete=models.CASCADE)

--- a/RedInvestigadores/core/templates/account/login.html
+++ b/RedInvestigadores/core/templates/account/login.html
@@ -63,8 +63,7 @@
                             <button type="submit" name="button" id="button">Entrar</button>
                             {% if form.errors %}
                               <p class=" label label-danger">
-                                Your username and password didn't match.
-                                Please try again.
+                                Tu nombre de usuario o contraseña no son correctos.
                               </p>
                             {% endif %}
                           </form>
@@ -79,19 +78,16 @@
                 <div class="col-md-12">
             			<h2>¿No tienes cuenta?</h2>
                     <p>
-                      <form class="forms">
-                        <label for="selector">¿Con qué perfil?:</label>
-                        <select id="selector" name="selector">
-                          <option value="">Ninguno</option>
-                          <option value="1">Estudiante</option>
-                          <option value="2">Investigador</option>
-                          <option value="3">Posdoctorado</option>
-                        </select><br><br>
-                        <form method="post">
+                      <form class="signup" id="signup_form" method="post">
                           {% csrf_token %}
                           {{ signupform.as_p }}
                           <button type="submit">Registrarse</button>
-                        </form>
+                          {% if form.errors %}
+                            <p class=" label label-danger">
+                              Ya existe el
+                            </p>
+                          {% endif %}
+                      </form>
                     </p>
                 </div>
               </div>

--- a/RedInvestigadores/core/templates/account/signup.html
+++ b/RedInvestigadores/core/templates/account/signup.html
@@ -6,7 +6,6 @@
     <meta charset="utf-8">
     <title>Login</title>
     <link rel="shortcut icon" href="{% static "img/keyword-research_icon-icons.com_537756_537756.ico" %}">
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
     <link rel='stylesheet prefetch' href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css'>
     <link rel='stylesheet prefetch' href='https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css'>
@@ -27,7 +26,6 @@
               <li><a href="{% url 'list_profiles' %}">Perfiles</a></li>
               <li><a href="{% url 'about_of' %}">Acerca de</a></li>
               {% if user.is_authenticated %}
-                <li><a href="{% url 'profile' request.user.id %}">Mi Perfil</a></li>
                 <li><a href="{% url 'logout' %}">Salir</a></li>
               {% else %}
                 <li><a href="{% url 'login' %}">Ingreso/Registro</a></li>
@@ -46,12 +44,35 @@
           </li>
           <li class="tab fancyTab">
           <div class="arrow-down"><div class="arrow-down-inner"></div></div>
-              <a id="tab4" href="#tabBody4" role="tab" aria-controls="tabBody4" aria-selected="true" data-toggle="tab" tabindex="0"><span class="fa fa-check"></span><span class="hidden-xs">Regístrate</span></a>
+              <a id="tab1" href="#tabBody1" role="tab" aria-controls="tabBody1" aria-selected="true" data-toggle="tab" tabindex="1"><span class="fa fa-check"></span><span class="hidden-xs">Regístrate</span></a>
               <div class="whiteBlock"></div>
           </li>
 
         </ul>
         <div id="myTabContent" class="tab-content fancyTabContent" aria-live="polite">
+          <div class="tab-pane  fade" id="tabBody1" role="tabpanel" aria-labelledby="tab1" aria-hidden="true" tabindex="1">
+            <div class="row">
+              <div class="col-md-12">
+                <h2>¿No tienes cuenta?</h2>
+                  <p>
+                    <form class="forms">
+                      <label for="selector">¿Con qué perfil?:</label>
+                      <select id="selector" name="selector">
+                        <option value="">Ninguno</option>
+                        <option value="1">Estudiante</option>
+                        <option value="2">Investigador</option>
+                        <option value="3">Posdoctorado</option>
+                      </select><br><br>
+                      <form method="post">
+                        {% csrf_token %}
+                        {{ form.as_p }}
+                        <button type="submit">Registrarse</button>
+                      </form>
+                  </p>
+              </div>
+            </div>
+          </div>
+
             <div class="tab-pane  fade active in" id="tabBody0" role="tabpanel" aria-labelledby="tab0" aria-hidden="false" tabindex="0">
                 <div>
                 	<div class="row">
@@ -61,35 +82,19 @@
                           <form method="post">
                             {% csrf_token %}
                             {{ form.as_p }}
+                            <p><a href="{% url 'password_reset' %}">Restaurar contraseña</a></p>
                             <button type="submit" name="button" id="button">Entrar</button>
+                            {% if form.errors %}
+                              <p class=" label label-danger">
+                                Your username and password didn't match.
+                                Please try again.
+                              </p>
+                            {% endif %}
                           </form>
                       </p>
                     </div>
                     </div>
                   </div>
-            </div>
-
-            <div class="tab-pane  fade" id="tabBody1" role="tabpanel" aria-labelledby="tab1" aria-hidden="true" tabindex="1">
-              <div class="row">
-                <div class="col-md-12">
-            			<h2>¿No tienes cuenta?</h2>
-                    <p>
-                      <form class="forms">
-                        <label for="selector">¿Con qué perfil?:</label>
-                        <select id="selector" name="selector">
-                          <option value="">Ninguno</option>
-                          <option value="1">Estudiante</option>
-                          <option value="2">Investigador</option>
-                          <option value="3">Posdoctorado</option>
-                        </select><br><br>
-                        <form method="post">
-                          {% csrf_token %}
-                          {{ form.as_p }}
-                          <button type="submit">Registrarse</button>
-                        </form>
-                    </p>
-                </div>
-              </div>
             </div>
         </div>
       </section>

--- a/RedInvestigadores/core/views.py
+++ b/RedInvestigadores/core/views.py
@@ -2,14 +2,15 @@ from django.shortcuts import render
 from django.urls import reverse_lazy
 from django.views import generic
 from django.http import HttpResponse
+from allauth.account.views import *
+from allauth.account.forms import LoginForm, SignupForm
 
-from .forms import CustomUserCreationForm
-from .models import Person, CustomUser
+from .forms import CustomLoginForm, CustomUserCreationForm
 
 class SignUp(generic.CreateView):
     form_class = CustomUserCreationForm
     success_url = reverse_lazy('login')
-    template_name = 'login.html'
+    template_name = 'registration/login.html'
 
 def home(request):
     return render(request, 'core/home.html')


### PR DESCRIPTION
Alternative login and signup were added using allauth:
-Login/signup now only use email, username is no longer used.
-Signup form has first name, last name, email and password as fields.
-Signup form has an additional state ("Estado") field, but it does not save the info to the DB.

There is no access to the new login/signup pages from the home page, but they can be
accessed through 'localhost:8000/accounts/login' and 'localhost:8000/accounts/signup',
respectively.
