### PR TITLE
Improved search. Further improvement necessary, but not by us.

### DIFF
--- a/RedInvestigadores/core/views.py
+++ b/RedInvestigadores/core/views.py
@@ -240,9 +240,13 @@ def get_user_profile(request, user_id):
 def search(request):
     if 'q' in request.GET and request.GET['q']:
         q = request.GET['q']
-        persons = Person.objects.filter(Q(first_name__icontains=q) | Q(last_name__icontains=q)).order_by('last_name')
+        split_q = q.split()
+        if len(split_q) < 3:
+            persons = Person.objects.filter(Q(first_name__icontains=q) | Q(last_name__icontains=q) | Q(first_name__icontains=split_q[0], last_name__icontains=q[-1])).order_by('last_name')
+        else:
+            persons = Person.objects.filter(Q(first_name__icontains=q) | Q(last_name__icontains=q) | Q(first_name__icontains=split_q[0], last_name__icontains=q[-1]) & Q(last_name__icontains=q[1]) | Q(first_name__icontains=split_q[0]) & Q(first_name__icontains=q[1]), last_name__icontains=q[-1]).order_by('last_name')
         affiliations = Affiliation.objects.filter(name__icontains=q).order_by('name')
-        publications = Publication.objects.filter(title__icontains=q).order_by('date')
+        publications = Publication.objects.filter(Q(title__icontains=q) | Q(date__icontains=q)).order_by('date')
         return render(request, 'core/search.html',
                       {'persons': persons,
                        'affiliations': affiliations,
@@ -250,7 +254,7 @@ def search(request):
                        'query': q})
 
     else:
-        return HttpResponse('Please submit a search term.')
+        return HttpResponse('Por favor, ingresa alguna palabra para buscar.')
 
 
 def profile_changes(request):


### PR DESCRIPTION
Search by person name assumes that the search terms are either:
-Only part of the first name
-Only part of the last name
-Part of the first name and part of the last name, in that order
-If first name and last name are searched, no middle names are considered, and a (regular) two part last name.

This should be improved, the natural step would be an advanced search, but it will not be implemented by our team.